### PR TITLE
Include all oxygen measurements

### DIFF
--- a/data-extraction/eicu_final_measurement_results.sql
+++ b/data-extraction/eicu_final_measurement_results.sql
@@ -19,5 +19,6 @@ FROM pc
 INNER JOIN chart
   ON chart.patientunitstayid = pc.icustay_id 
 WHERE chart.nursingchartcelltypevalname = "O2 Saturation"
+/* The following selection can also be done in R to investigate any data quality issues
 AND chart.nursingchartoffset / (24 * 60) > 0
-AND chart.nursingchartoffset / (24 * 60) < pc.icu_length_of_stay
+AND chart.nursingchartoffset / (24 * 60) < pc.icu_length_of_stay */


### PR DESCRIPTION
I suggest we do not discard oxygen measurements outside of the timeframe that we are expecting them. Then, we can investigate any abnormalities to get a better idea of the quality of the data / time stamps.